### PR TITLE
GH-554 添加数据源后再打开添加弹窗，数据源驱动的默认选项没有清空

### DIFF
--- a/spark-yun-frontend/src/views/datasource/add-modal/index.vue
+++ b/spark-yun-frontend/src/views/datasource/add-modal/index.vue
@@ -269,6 +269,7 @@ function showModal(cb: () => void, data: any): void {
 }
 
 function getDriverIdList(e: boolean) {
+  driverIdList.value = []
   if (e && formData.dbType) {
     GetDriverListData({
       page: 0,


### PR DESCRIPTION
GH-554