### PR TITLE
GH-716 作业流开发区域设置为可拖动的，现阶超过一定行数就需要滑动不方便，同时日志显示的占用空间过大

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           token: ${{ env.ADMIN_GITHUB_TOKEN }}
           repository: "isxcode/spark-yun-vip"
-          path: "spark-yun/"
+          path: "/home/runner/work/spark-yun/spark-yun/spark-yun-vip"
           ref: 'main'
 
       - name: Cache gradle


### PR DESCRIPTION
GH-716